### PR TITLE
Remove XML attributes that break things

### DIFF
--- a/GUI Part V/PowerShell_GUI_Template.ps1
+++ b/GUI Part V/PowerShell_GUI_Template.ps1
@@ -36,7 +36,21 @@ $psCmd = [PowerShell]::Create().AddScript({
 </Window>
 "@
 
+    # Remove XML attributes that break a couple things.
+    #   Without this, you must manually remove the attributes
+    #   after pasting from Visual Studio. If more attributes
+    #   need to be removed automatically, add them below.
+    $AttributesToRemove = @(
+        'x:Class',
+        'mc:Ignorable'
+    )
 
+    foreach ($Attrib in $AttributesToRemove) {
+        if ( $xaml.Window.GetAttribute($Attrib) ) {
+             $xaml.Window.RemoveAttribute($Attrib)
+        }
+    }
+    
     $reader=(New-Object System.Xml.XmlNodeReader $xaml)
     
     $syncHash.Window=[Windows.Markup.XamlReader]::Load( $reader )


### PR DESCRIPTION
This little bit of code removes the x:Class and mc:Ignorable attributes.  These attributes are generated by Visual Studio, and if they are not removed, the window will not render.  Unfortunately the code still runs and the only way to stop it is kill the PowerShell processes.